### PR TITLE
Use PKCE for Todoist OAuth

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,17 +1,48 @@
 const baseURL = 'https://todoist.com'
-const state = crypto.randomUUID()
+
+function base64UrlEncode(buffer) {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+function generateCodeVerifier() {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  return base64UrlEncode(bytes)
+}
+
+async function generateCodeChallenge(codeVerifier) {
+  const data = new TextEncoder().encode(codeVerifier)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return base64UrlEncode(digest)
+}
 
 class Api {
   async authorize() {
     const redirectURL = chrome.identity.getRedirectURL('oauth2')
+    const state = crypto.randomUUID()
+    const codeVerifier = generateCodeVerifier()
+    const codeChallenge = await generateCodeChallenge(codeVerifier)
 
     const authURL = new URL(`${baseURL}/oauth/authorize`)
     authURL.searchParams.set('client_id', CLIENT_ID)
     authURL.searchParams.set('scope', 'data:read_write')
     authURL.searchParams.set('state', state)
     authURL.searchParams.set('redirect_uri', redirectURL)
+    authURL.searchParams.set('response_type', 'code')
+    authURL.searchParams.set('code_challenge', codeChallenge)
+    authURL.searchParams.set('code_challenge_method', 'S256')
 
-const responseUrl = await new Promise((resolve, reject) => {
+    const responseUrl = await new Promise((resolve, reject) => {
       chrome.identity.launchWebAuthFlow(
         { url: authURL.toString(), interactive: true },
         responseUrl => {
@@ -25,20 +56,43 @@ const responseUrl = await new Promise((resolve, reject) => {
     })
 
     const url = new URL(responseUrl)
+    const error = url.searchParams.get('error')
+
+    if (error !== null) {
+      throw new Error(`Authorization failed: ${error}`)
+    }
+
+    if (url.searchParams.get('state') !== state) {
+      throw new Error('Authorization failed: state mismatch')
+    }
+
     const code = url.searchParams.get('code')
+
+    if (code === null) {
+      throw new Error('Authorization failed: missing code')
+    }
 
     const response = await fetch(`${baseURL}/oauth/access_token`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         client_id: CLIENT_ID,
-        client_secret: CLIENT_SECRET,
-        code: code,
-        redirect_uri: redirectURL
+        code,
+        redirect_uri: redirectURL,
+        code_verifier: codeVerifier
       })
     })
 
     const data = await response.json()
+
+    if (!response.ok) {
+      throw new Error(data.error ?? `Token exchange failed: ${response.status}`)
+    }
+
+    if (typeof data.access_token !== 'string') {
+      throw new Error('Token exchange failed: missing access token')
+    }
+
     chrome.storage.sync.set({ token: data.access_token })
   }
 

--- a/options.js
+++ b/options.js
@@ -12,7 +12,7 @@ document.querySelector('#login').addEventListener('click', async () => {
 })
 
 document.querySelector('#logout').addEventListener('click', () => {
-  chrome.storage.sync.set({ token: undefined }, () => {
+  chrome.storage.sync.remove('token', () => {
     document.querySelector('#not-login').style.display = 'block'
     document.querySelector('#logging').style.display = 'none'
   })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,8 +17,7 @@ module.exports = {
 
   plugins: [
     new webpack.DefinePlugin({
-      CLIENT_ID: JSON.stringify(process.env.CLIENT_ID),
-      CLIENT_SECRET: JSON.stringify(process.env.CLIENT_SECRET)
+      CLIENT_ID: JSON.stringify(process.env.CLIENT_ID)
     })
   ]
 }


### PR DESCRIPTION
## Summary
- replace Todoist OAuth client secret exchange with PKCE
- validate OAuth state and token exchange responses
- remove CLIENT_SECRET injection from the extension bundle
- remove stored token on logout instead of saving undefined

## Verification
- npm run build
- rg -n "CLIENT_SECRET|client_secret" . -g '!node_modules'